### PR TITLE
fix: Provide valid links in documentation

### DIFF
--- a/documentation/adyen-deploy.md
+++ b/documentation/adyen-deploy.md
@@ -51,12 +51,12 @@ Before deploying the resources, set up the service principal in the Azure Active
 
 The simplest method is using the Azure CLI.
 
-1. [Sign in with Azure CLI](../cli/azure/authenticate-azure-cli.md#sign-in-interactively):
+1. [Sign in with Azure CLI](https://docs.microsoft.com/cli/azure/authenticate-azure-cli#sign-in-interactively):
 
     ```azurecli-interactive
     az login
     ```
-2. [Create an Azure service principal with the Azure CLI](../cli/azure/create-an-azure-service-principal-azure-cli.md#password-based-authentication):
+2. [Create an Azure service principal with the Azure CLI](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli#password-based-authentication):
 
     ```azurecli-interactive
     az ad sp create-for-rbac --name <chosen-name-for-your-service-principal> --skip-assignment
@@ -106,9 +106,9 @@ You can deploy by running the `deploy.ps1` PowerShell script at the root of the 
 
 ## Publish the API Management developer portal
 
-This example project uses the hosted [API Management developer portal](api-management-howto-developer-portal-customize.md). 
+This example project uses the hosted [API Management developer portal](https://docs.microsoft.com/azure/api-management/api-management-howto-developer-portal). 
 
-You are required to complete a manual step to publish and make the resources visible to customers. See the [Publish the portal](https://docs.microsoft.com/en-us/azure/api-management/api-management-howto-developer-portal-customize#publish) for instructions.
+You are required to complete a manual step to publish and make the resources visible to customers. See the [Publish the portal](https://docs.microsoft.com/azure/api-management/api-management-howto-developer-portal-customize#publish) for instructions.
 
 ## Next Steps
 * Learn more about [deploying API Management monetization with Adyen](adyen-details.md).

--- a/documentation/adyen-details.md
+++ b/documentation/adyen-details.md
@@ -83,7 +83,7 @@ Unlike the [Stripe](./stripe-deploy.md) implementation, Adyen's subscription cre
 ### Step 10: Billing
 
 On the first of each month, a [CRON job](https://www.npmjs.com/package/node-cron) is run. The CRON job is defined in the main [index.ts file](../app/src/index.ts) for the app, and:  
-* Calls into the [calculateInvoices method on the AdyenBillingService](../app/src/services/AdyenBillingService.ts) to calculate the invoices for all API Management subscriptions. 
+* Calls into the [calculateInvoices method on the AdyenBillingService](../app/src/services/adyenBillingService.ts) to calculate the invoices for all API Management subscriptions. 
 * Charges the consumer's cards.
 
 This method contains the logic for calculating the payment amount, using:

--- a/documentation/adyen-details.md
+++ b/documentation/adyen-details.md
@@ -30,7 +30,7 @@ The API consumer flow describes the end-to-end user journey supported by the sol
 ### API consumer flow
 
 1. Consumer selects **Sign up** in the API Management developer portal.
-2. Developer portal redirects consumer to the billing portal app to register their account via [API Management delegation](api-management-howto-setup-delegation.md).
+2. Developer portal redirects consumer to the billing portal app to register their account via [API Management delegation](https://docs.microsoft.com/azure/api-management/api-management-howto-setup-delegation).
 3. Upon successful registration, consumer is authenticated and returned back to the developer portal.
 4. Consumer selects a product to subscribe to in the developer portal.
 5. Developer portal redirects consumer to the billing portal app via delegation.
@@ -45,7 +45,7 @@ The API consumer flow describes the end-to-end user journey supported by the sol
 1. Find the developer portal for an API Management service at `https://{ApimServiceName}.developer.azure-api.net`.
 1. Select **Sign Up** to be redirected to the billing portal app.
 1. On the billing portal app, register for an account. 
-    * This is handled via [user registration delegation](api-management-howto-setup-delegation.md#-delegating-developer-sign-in-and-sign-up).
+    * This is handled via [user registration delegation](https://docs.microsoft.com/azure/api-management/api-management-howto-setup-delegation#-delegating-developer-sign-in-and-sign-up).
 1. Upon successful account creation, the consumer is authenticated and redirected to the developer portal.
 
 Once the consumer creates an account, they'll only need to sign into the existing account to browse APIs and products from the developer portal.
@@ -55,7 +55,7 @@ Once the consumer creates an account, they'll only need to sign into the existin
 1. Log into the developer portal account.
 1. Search for a product and select **Subscribe** to begin a new subscription. 
 1. Consumer will be redirected to the billing portal app. 
-   * This is handled via [product subscription delegation](api-management-howto-setup-delegation.md#-delegating-product-subscription).
+   * This is handled via [product subscription delegation](https://docs.microsoft.com/azure/api-management/api-management-howto-setup-delegation#-delegating-product-subscription).
 
 ### Steps 5 - 6: Billing portal
 
@@ -83,7 +83,7 @@ Unlike the [Stripe](./stripe-deploy.md) implementation, Adyen's subscription cre
 ### Step 10: Billing
 
 On the first of each month, a [CRON job](https://www.npmjs.com/package/node-cron) is run. The CRON job is defined in the main [index.ts file](../app/src/index.ts) for the app, and:  
-* Calls into the [calculateInvoices method on the AdyenBillingService](../src/services/AdyenBillingService.ts) to calculate the invoices for all API Management subscriptions. 
+* Calls into the [calculateInvoices method on the AdyenBillingService](../app/src/services/AdyenBillingService.ts) to calculate the invoices for all API Management subscriptions. 
 * Charges the consumer's cards.
 
 This method contains the logic for calculating the payment amount, using:

--- a/documentation/deployment-details.md
+++ b/documentation/deployment-details.md
@@ -3,14 +3,14 @@
 In this article, you will learn about the technology, resources, and tools that API Management uses to deploy your monetization strategy. Using the provided demo, you will deploy a monetization strategy and define a set of products, APIs, and named values. 
 
 As part of the demo, you'll deploy the following resources:
-- An [API Management service](https://azure.microsoft.com/en-gb/services/api-management/), with the API Management resources required to support the demo project (APIs, Products, Policies, Named Values).
-- An [App Service plan](../app-service/overview.md).
-- A [Web App for containers](https://azure.microsoft.com/en-gb/services/app-service/containers/), using the billing portal app container image.
-- A [Service Principal role-based access control assignment](../role-based-access-control/overview.md).
+- An [API Management service](https://azure.microsoft.com/services/api-management/), with the API Management resources required to support the demo project (APIs, Products, Policies, Named Values).
+- An [App Service plan](https://docs.microsoft.com/azure/app-service/overview).
+- A [Web App for containers](https://azure.microsoft.com/services/app-service/containers/), using the billing portal app container image.
+- A [Service Principal role-based access control assignment](https://docs.microsoft.com/azure/role-based-access-control/overview).
 
 ## Bicep templates
 
-This project is currently using [Bicep](../azure-resource-manager/templates/bicep-overview.md) for local development and deployment. Bicep is a templating language for declaratively deploying Azure resources. Currently, the **Deploy to Azure** button does not support Bicep. 
+This project is currently using [Bicep](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview?tabs=bicep) for local development and deployment. Bicep is a templating language for declaratively deploying Azure resources. Currently, the **Deploy to Azure** button does not support Bicep. 
 
 * Prior to deployment, Bicep must be decompiled into an Azure Resource Manager template, which happens when the solution is built by running the [build.ps1](../build.ps1) script.
 * You can find the Azure Resource Manager template generated on build in the [/output](../output/) folder.
@@ -161,9 +161,9 @@ Named values are defined in the [templates/apimmonetization-namedValues](../temp
 
 ## Billing portal
 
-Aside from API Management, the deployment script also deploys the billing portal resource. The billing portal is a `Node.js` app. Consumers directed to the billing portal to activate their subscriptions. You can handle the integration between API Management and the billing portal with the [user registration and product subscription delegation features in API Management](./azure/api-management/api-management-howto-setup-delegation).
+Aside from API Management, the deployment script also deploys the billing portal resource. The billing portal is a `Node.js` app. Consumers directed to the billing portal to activate their subscriptions. You can handle the integration between API Management and the billing portal with the [user registration and product subscription delegation features in API Management](https://docs.microsoft.com/azure/api-management/api-management-howto-setup-delegation).
 
-As part of the main deployment, the billing portal app is deployed to [Azure Web App for Containers](https://azure.microsoft.com/en-gb/services/app-service/containers/). The container image is pulled from the [GitHub Container Registry](https://docs.github.com/en/packages/guides/about-github-container-registry) associated with this repo.
+As part of the main deployment, the billing portal app is deployed to [Azure Web App for Containers](https://azure.microsoft.com/services/app-service/containers/). The container image is pulled from the [GitHub Container Registry](https://docs.github.com/en/packages/guides/about-github-container-registry) associated with this repo.
 
 You can also add configuration to the app as part of the payment provider initialization (Adyen and Stripe).
 

--- a/documentation/stripe-deploy.md
+++ b/documentation/stripe-deploy.md
@@ -45,12 +45,12 @@ Before deploying the resources, set up the service principal in the Azure Active
 
 The simplest method is using the Azure CLI.
 
-1. [Sign in with Azure CLI](../cli/azure/authenticate-azure-cli.md#sign-in-interactively):
+1. [Sign in with Azure CLI](https://docs.microsoft.com/cli/azure/authenticate-azure-cli#sign-in-interactively):
 
     ```azurecli-interactive
     az login
     ```
-2. [Create an Azure service principal with the Azure CLI](../cli/azure/create-an-azure-service-principal-azure-cli.md#password-based-authentication):
+2. [Create an Azure service principal with the Azure CLI](https://docs.microsoft.com/cli/azure/create-an-azure-service-principal-azure-cli#password-based-authentication):
 
     ```azurecli-interactive
     az ad sp create-for-rbac --name <chosen-name-for-your-service-principal> --skip-assignment
@@ -100,7 +100,7 @@ You can deploy by running the `deploy.ps1` PowerShell script at the root of the 
 
 ## Publish the API Management developer portal
 
-This example project uses the hosted [API Management developer portal](api-management-howto-developer-portal-customize.md). 
+This example project uses the hosted [API Management developer portal](https://docs.microsoft.com/azure/api-management/api-management-howto-developer-portal). 
 
 You are required to complete a manual step to publish and make the resources visible to customers. See the [Publish the portal](https://docs.microsoft.com/en-us/azure/api-management/api-management-howto-developer-portal-customize#publish) for instructions.
 

--- a/documentation/stripe-details.md
+++ b/documentation/stripe-details.md
@@ -4,7 +4,7 @@ You can configure the API Management and Stripe to implement products defined in
 
 To deliver a consistent end-to-end API consumer experience, you'll synchronize the API Management product policies and the Stripe configuration using a shared configuration file [payment/monetizationModels.json](../payment/monetizationModels.json).
 
-In this demo project, we'll implement the example revenue model defined in [the monetization overview](./how-to-think-about-monetization.md#step-4---design-the-revenue-model) to demonstrate integrating Azure API Management with Stripe.
+In this demo project, we'll implement the example revenue model defined in [the monetization overview](https://docs.microsoft.com/azure/api-management/monetization-overview#step-4---design-the-revenue-model) to demonstrate integrating Azure API Management with Stripe.
 
 ## Stripe 
 
@@ -19,7 +19,7 @@ In Stripe, you can define one or more associated prices against a product. Recur
 | `Licensed` | Billed automatically at the given interval. In the example, it's set to monthly. |
 | `Metered` | Calculates the monthly cost based on <ul><li>Usage records</li> <li>The set price per unit</li></ul> |
 
-The following table builds on the conceptual revenue model in [the monetization overview](how-to-think-about-monetization.md) and provides more detail about implementing using API Management and Stripe:
+The following table builds on the conceptual revenue model in [the monetization overview](https://docs.microsoft.com/azure/api-management/monetization-overview) and provides more detail about implementing using API Management and Stripe:
 
 | Products implemented in both API Management and Stripe | Pricing model    | Stripe configuration                                                                                                                                                      | Quality of service (API Management product policies)                                                                  |
 |------------------------------------------------|------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
@@ -47,7 +47,7 @@ The API consumer flow describes the end-to-end user journey supported by the sol
 ### API consumer flow
 
 1. Consumer selects **Sign up** in the API Management developer portal.
-2. Developer portal redirects consumer to the billing portal app to register their account via [API Management delegation](api-management-howto-setup-delegation.md).
+2. Developer portal redirects consumer to the billing portal app to register their account via [API Management delegation](https://docs.microsoft.com/azure/api-management/api-management-howto-setup-delegation).
 3. Upon successful registration, consumer is authenticated and returned back to the developer portal.
 4. Consumer selects a product to subscribe to in the developer portal.
 5. Developer portal redirects consumer to the billing portal app via delegation.
@@ -63,7 +63,7 @@ The API consumer flow describes the end-to-end user journey supported by the sol
 1. Find the developer portal for an API Management service at `https://{ApimServiceName}.developer.azure-api.net`.
 1. Select **Sign Up** to be redirected to the billing portal app.
 1. On the billing portal app, register for an account.
-    * Handled via [user registration delegation](api-management-howto-setup-delegation.md#-delegating-developer-sign-in-and-sign-up).
+    * Handled via [user registration delegation](https://docs.microsoft.com/azure/api-management/api-management-howto-setup-delegation#-delegating-developer-sign-in-and-sign-up).
 1. Upon successful account creation, the consumer is authenticated and redirected to the developer portal.
 
 Once the consumer creates an account, they'll only need to sign into the existing account to browse APIs and products from the developer portal.
@@ -73,7 +73,7 @@ Once the consumer creates an account, they'll only need to sign into the existin
 1. Log into the developer portal.
 1. Search for a product and select **Subscribe** to begin a new subscription. 
 1. Consumer will be redirected to the billing portal app. 
-   * This is handled via [product subscription delegation](api-management-howto-setup-delegation.md#-delegating-product-subscription).
+   * This is handled via [product subscription delegation](https://docs.microsoft.com/azure/api-management/api-management-howto-setup-delegation#-delegating-product-subscription).
 
 ### Steps 5 - 6: Billing portal
 


### PR DESCRIPTION
Closes #25 

All the changes are to links used in the documentation.  Have used absolute rather than relative paths whenever docs.microsoft.com is referenced.